### PR TITLE
CFD custom closes default to "no action" and allow non-admins to close CFDs

### DIFF
--- a/xfdcloser-src/data.js
+++ b/xfdcloser-src/data.js
@@ -31,7 +31,6 @@ const resultsData = [
 		title: "Close discussion as \"delete\"",
 		allowSpeedy: true,
 		allowSoft: true,
-		sysopOnly: true,
 		venues: ["cfd"],
 		actions: ["noActions"]
 	},


### PR DESCRIPTION
For CFD custom closes, change default from "remove templates, tag talk pages" to "no action"

Resolves #84
Resolves #92