### PR TITLE
Allow non-admins to close CFDs as delete

### DIFF
--- a/xfdcloser-src/data.js
+++ b/xfdcloser-src/data.js
@@ -31,7 +31,6 @@ const resultsData = [
 		title: "Close discussion as \"delete\"",
 		allowSpeedy: true,
 		allowSoft: true,
-		sysopOnly: true,
 		venues: ["cfd"],
 		actions: ["noActions"]
 	},


### PR DESCRIPTION
Allow non-admins to close CFDs by removing "sysopOnly" restriction from CfD Delete config in data.js

Resolves #92 