### PR TITLE
build: mkdir the "dist" directory if it doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": "https://github.com/wikimedia-gadgets/xfdcloser",
   "browser": "index.js",
   "scripts": {
-    "mkdir-dist": "node -e \"require('fs').mkdirSync('dist',{recursive:true})\"",
     "build:bundle": "npm run mkdir-dist && browserify xfdcloser-src/App.js --debug -t babelify --outfile dist/core.js",
     "build:concat": "npm run mkdir-dist && concat-cli -f \"core-comment-top.js\" dist/core.min.js \"core-comment-bottom.js\" -o dist/core-gadget.js",
     "build:css": "npm run mkdir-dist && node bin/concatCss",
@@ -30,6 +29,7 @@
     "lint:es6": "eslint \"xfdcloser-src/**/*.js\" \"test/*\"",
     "lint:fix": "npm run lint:es6:fix && npm run lint:bin:fix && npm run lint:css:fix",
     "lint": "npm run lint:es6 && npm run lint:es5 && npm run lint:css",
+    "mkdir-dist": "node -e \"require('fs').mkdirSync('dist',{recursive:true})\"",
     "start": "npm run build:dev && node bin/server",
     "test:all": "node bin/testall && npm run test",
     "test:delay": "mocha --delay --require @babel/register --reporter list",


### PR DESCRIPTION
Why
- eliminate the error "Error: ENOENT: no such file or directory, open '/workspaces/xfdcloser/dist/loader-dev.js'", which can confuse devs and take time to debug
- the error is caused by a missing /dist/ directory, which is a common situation. for example your first time `git clone`ing the repo

What
- create `npm run mkdir-dist`, which creates the /dist/ directory if it doesn't exist, is operating system agnostic, and does not throw an error if the directory is already created
- add `npm run mkdir-dist &&` to all build scripts that require it