### PR TITLE
server: remind user that it doesn't refresh live

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -19,5 +19,5 @@ const server = http.createServer((request, response) => {
 });
 
 server.listen(port, hostname, () => {
-	console.log(`Server running at http://${hostname}:${port}/`);
+	console.log(`Server running at http://${hostname}:${port}/ . Don't forget to close the server (ctrl-c) and restart it (npm start) every time you make a code change.`);
 });


### PR DESCRIPTION
Why
- in some other wikimedia-gadgets repos, if you do `npm start` then save a code change, it is instantly applied
- in this repo, the change is not instantly applied. everything needs a rebuild

What
- remind the user about this by adding it to the console.log message that they see after they do `npm start`