### PR TITLE
Rename {{Relist}} to {{XfD relist}}

### DIFF
--- a/test/testResult.js
+++ b/test/testResult.js
@@ -124,19 +124,19 @@ describe("Result", function() {
 			assert.strictEqual(model.showNewSentenceOption, false);
 		});
 		it("correctly generates preview wikitext", function() {
-			assert.strictEqual(model.previewWikitext, "{{Relist|1=}}", "Empty rationale");
+			assert.strictEqual(model.previewWikitext, "{{XfD relist|1=}}", "Empty rationale");
 			model.setRationale("   ");
-			assert.strictEqual(model.previewWikitext, "{{Relist|1=}}", "Whitespace-only rationale");
+			assert.strictEqual(model.previewWikitext, "{{XfD relist|1=}}", "Whitespace-only rationale");
 			model.setRationale("Foo");
-			assert.strictEqual(model.previewWikitext, "{{Relist|1=Foo}}", "Regular rationale");
+			assert.strictEqual(model.previewWikitext, "{{XfD relist|1=Foo}}", "Regular rationale");
 			model.setRationale("Foo  ");
-			assert.strictEqual(model.previewWikitext, "{{Relist|1=Foo}}", "Regular rationale with trailing whitespace");
+			assert.strictEqual(model.previewWikitext, "{{XfD relist|1=Foo}}", "Regular rationale with trailing whitespace");
 			model.setRationale("[[Foo|Foobar]]");
-			assert.strictEqual(model.previewWikitext, "{{Relist|1=[[Foo|Foobar]]}}", "Rationale with piped wikilink");
+			assert.strictEqual(model.previewWikitext, "{{XfD relist|1=[[Foo|Foobar]]}}", "Rationale with piped wikilink");
 			model.setRationale("{{tl|foo}}");
-			assert.strictEqual(model.previewWikitext, "{{Relist|1={{tl|foo}}}}", "Rationale with template containing pipe");
+			assert.strictEqual(model.previewWikitext, "{{XfD relist|1={{tl|foo}}}}", "Rationale with template containing pipe");
 			model.setRationale("some|reason");
-			assert.strictEqual(model.previewWikitext, "{{Relist|1=some&#124;reason}}", "Rationale with loose pipe");
+			assert.strictEqual(model.previewWikitext, "{{XfD relist|1=some&#124;reason}}", "Rationale with loose pipe");
 		});
 		it("only emits update if updated rationale is the same as the current rationale", function() {
 			const emittedUpdate1 = model.setRationale("Foo") !== false;

--- a/test/testTaskGetRelistInfo.js
+++ b/test/testTaskGetRelistInfo.js
@@ -64,12 +64,12 @@ describe("GetRelistInfo", function() {
 	it("gets relist template for first relist", function() {
 		const content = "Lorem ipsum dorem sum";
 		const relistTemplate = task.getRelistTemplate(content);
-		assert.strictEqual(relistTemplate, "{{subst:Relist|1=|2=1}}");
+		assert.strictEqual(relistTemplate, "{{subst:XfD relist|1=|2=1}}");
 	});
 	it("gets relist template for second relist", function() {
 		const content = "Lorem ipsum dorem sum\n[[Wikipedia:Deletion process#Relisting discussions|Relisted]] bla blah<!-- from Template:Relist --><noinclude>[[Category:Relisted AfD debates|24 Mani Neram]]</noinclude></div><!-- Please add new comments below this line -->";
 		const relistTemplate = task.getRelistTemplate(content);
-		assert.strictEqual(relistTemplate, "{{subst:Relist|1=|2=2}}");
+		assert.strictEqual(relistTemplate, "{{subst:XfD relist|1=|2=2}}");
 	});
 	it("gets relist template for third relist", function() {
 		const content = `Lorem ipsum dorem sum
@@ -77,18 +77,18 @@ describe("GetRelistInfo", function() {
 Foo bar baz qux
 [[Wikipedia:Deletion process#Relisting discussions|Relisted]] bla blah<!-- from Template:Relist --><noinclude>[[Category:Relisted AfD debates|24 Mani Neram]]</noinclude></div><!-- Please add new comments below this line -->`;
 		const relistTemplate = task.getRelistTemplate(content);
-		assert.strictEqual(relistTemplate, "{{subst:Relist|1=|2=3}}");
+		assert.strictEqual(relistTemplate, "{{subst:XfD relist|1=|2=3}}");
 	});
 	it("gets relist template with relist comment", function() {
 		result.setRationale("Some reasoning here");
 		const relistTemplate = task.getRelistTemplate("");
-		assert.strictEqual(relistTemplate, "{{subst:Relist|1=Some reasoning here|2=1}}");
+		assert.strictEqual(relistTemplate, "{{subst:XfD relist|1=Some reasoning here|2=1}}");
 	});
 	it("gets relist wikitexts for RfD", function() {
 		const content = "====Foobar====\n*<span id='id1'>Page</span>";
 		const result = task.getRelistWikitext(content);
 		assert.deepStrictEqual(Object.keys(result), ["newWikitext", "oldLogWikitext"]);
-		assert.strictEqual(result.newWikitext, "====Foobar====\n*<span id='id1'>Page</span>\n{{subst:Relist|1=|2=1}}\n");
+		assert.strictEqual(result.newWikitext, "====Foobar====\n*<span id='id1'>Page</span>\n{{subst:XfD relist|1=|2=1}}\n");
 		assert.strictEqual(result.oldLogWikitext, `====Foobar====\n{{subst:rfd relisted|page=${GetRelistInfo.today}|Foobar}}`);
 	});
 	it("gets relist wikitexts for RfD, multiple pages", function() {
@@ -102,7 +102,7 @@ Foo bar baz qux
 		const content = "====Foobar====\n*<span id='id1'>Page</span>";
 		const result = task.getRelistWikitext(content);
 		assert.deepStrictEqual(Object.keys(result), ["newWikitext", "oldLogWikitext"]);
-		assert.strictEqual(result.newWikitext, "====Foobar====\n*<span id='id1'>Page</span>\n{{subst:Relist|1=|2=1}}\n");
+		assert.strictEqual(result.newWikitext, "====Foobar====\n*<span id='id1'>Page</span>\n{{subst:XfD relist|1=|2=1}}\n");
 		assert.strictEqual(result.oldLogWikitext, "====Foobar====\n{{subst:cfd relisted|Foobar}}");
 	});
 	it("gets relist wikitexts for MfD", function() {
@@ -110,7 +110,7 @@ Foo bar baz qux
 		const content = "====Foobar====\n:{{pagelinks}}\nLorem ipsum";
 		const result = task.getRelistWikitext(content);
 		assert.deepStrictEqual(Object.keys(result), ["newWikitext", "oldLogWikitext"]);
-		assert.strictEqual(result.newWikitext, "====Foobar====\n:{{pagelinks}}\n{{subst:mfdr}}\nLorem ipsum\n{{subst:Relist|1=|2=1}}");
+		assert.strictEqual(result.newWikitext, "====Foobar====\n:{{pagelinks}}\n{{subst:mfdr}}\nLorem ipsum\n{{subst:XfD relist|1=|2=1}}");
 		assert.strictEqual(result.oldLogWikitext, "");
 	});
 	it("gets relist wikitexts for TfD", function() {
@@ -122,7 +122,7 @@ Foo bar baz qux
 		const content = "====Foobar====\nLorem ipsum";
 		const result = task.getRelistWikitext(content);
 		assert.deepStrictEqual(Object.keys(result), ["newWikitext", "oldLogWikitext"]);
-		assert.strictEqual(result.newWikitext, "====Foobar====\nLorem ipsum\n{{subst:Relist|1=|2=1}}\n");
+		assert.strictEqual(result.newWikitext, "====Foobar====\nLorem ipsum\n{{subst:XfD relist|1=|2=1}}\n");
 		assert.strictEqual(result.oldLogWikitext, `====Foobar====
 {{subst:Tfd top|'''relisted'''}} on [[${task.todaysLogpage}#Foobar|${GetRelistInfo.today}]]. <small>[[Wikipedia:NACD|(non-admin closure)]]</small> ~~~~
 * {{tfd links|Foobar}}
@@ -138,7 +138,7 @@ Foo bar baz qux
 		const content = "====Foobar====\nLorem ipsum";
 		const result = task.getRelistWikitext(content);
 		assert.deepStrictEqual(Object.keys(result), ["newWikitext", "oldLogWikitext"]);
-		assert.strictEqual(result.newWikitext, "====Foobar====\nLorem ipsum\n{{subst:Relist|1=|2=1}}\n");
+		assert.strictEqual(result.newWikitext, "====Foobar====\nLorem ipsum\n{{subst:XfD relist|1=|2=1}}\n");
 		assert.strictEqual(result.oldLogWikitext, `====Foobar====
 {{subst:Tfd top|'''relisted'''}} on [[${task.todaysLogpage}#Foobar|${GetRelistInfo.today}]]. <small>[[Wikipedia:NACD|(non-admin closure)]]</small> ~~~~
 * {{tfd links|Foobar}}
@@ -151,7 +151,7 @@ Foo bar baz qux
 		const content = "====Foobar====\nLorem ipsum <noinclude>[[Wikipedia:Articles for deletion/Log/2020 October 8#{{anchorencode:Foobar}}|View log]]</noinclude>)\nBax qux etc";
 		const result = task.getRelistWikitext(content);
 		assert.deepStrictEqual(Object.keys(result), ["newWikitext", "oldLogWikitext"]);
-		assert.strictEqual(result.newWikitext, `====Foobar====\nLorem ipsum <noinclude>[[${task.todaysLogpage}#{{anchorencode:Foobar}}|View log]]</noinclude>)\nBax qux etc\n{{subst:Relist|1=|2=1}}\n`);
+		assert.strictEqual(result.newWikitext, `====Foobar====\nLorem ipsum <noinclude>[[${task.todaysLogpage}#{{anchorencode:Foobar}}|View log]]</noinclude>)\nBax qux etc\n{{subst:XfD relist|1=|2=1}}\n`);
 		assert.strictEqual(result.oldLogWikitext, "");
 	});
 });

--- a/xfdcloser-src/Controllers/Tasks/GetRelistInfo.js
+++ b/xfdcloser-src/Controllers/Tasks/GetRelistInfo.js
@@ -42,7 +42,7 @@ export default class RelistInfo extends TaskItemController {
 			/\[\[Wikipedia:Deletion process#Relisting discussions\|Relisted\]\]/g
 		);
 		const relistNumber = relists ? relists.length + 1 : 1;
-		return `{{subst:Relist|1=${this.model.result.getRelistComment()}|2=${relistNumber}}}`;	
+		return `{{subst:XfD relist|1=${this.model.result.getRelistComment()}|2=${relistNumber}}}`;	
 	}
 
 	/**

--- a/xfdcloser-src/Models/Result.js
+++ b/xfdcloser-src/Models/Result.js
@@ -177,7 +177,7 @@ class Result {
 	 */
 	get previewWikitext() {
 		if (this.type === "relist") {
-			return `{{Relist|1=${this.getRelistComment()}}}`;
+			return `{{XfD relist|1=${this.getRelistComment()}}}`;
 		} else { 
 			const resultText = this.isMultimode ? this.resultSummary.trim() : this.singleModeResult.getResultText();
 			const resultWikitext = resultText ? `'''${resultText}'''` : "";


### PR DESCRIPTION
{{Relist}} is a redirect to {{XfD relist}}, bypassing redirect is a good idea.

Resolves #90