### PR TITLE
App: capitalize "XFDC Prefs" in menu

### DIFF
--- a/xfdcloser-src/App.js
+++ b/xfdcloser-src/App.js
@@ -25,7 +25,7 @@ import DiscussionView from "./Views/DiscussionView";
 	});
 
 	// Preferences portlet link
-	mw.util.addPortletLink("p-cactions", "#", "XFDC prefs", "p-xfdc-prefs", "XFDcloser preferences");
+	mw.util.addPortletLink("p-cactions", "#", "XFDC Prefs", "p-xfdc-prefs", "XFDcloser preferences");
 	$("#p-xfdc-prefs").click(e => {
 		e.preventDefault();
 		windowSetManager.openWindow("prefs", {


### PR DESCRIPTION
XFDC prefs and XFDC Unlink having different capitalization is bugging me. Capitalize XFDC Prefs to make it consistent.

<img width="296" height="532" alt="image" src="https://github.com/user-attachments/assets/8e56bca1-fc10-4a6d-b6ea-76305c0eb9ef" />