### PR TITLE
Modify deploy.js to accept site and accessToken variables from credentials file

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -37,10 +37,22 @@
  * - Changes to gadget definitions need to be done manually
  */
 const fs = require("fs");
-const {mwn} = require("mwn");
+const path = require("path");
+const {Mwn} = require("mwn");
 const {execSync} = require("child_process");
 const prompt = require("prompt-sync")({sigint: true});
-const {username, password} = require("./credentials.json");
+const credentials = (() => {
+	const filePath = path.join(__dirname, "credentials.json");
+	if (fs.existsSync(filePath)) {
+		try {
+			return JSON.parse(fs.readFileSync(filePath, "utf8"));
+		} catch (e) {
+			console.error("Failed to parse bin/credentials.json:", e);
+			process.exit(1);
+		}
+	}
+	return {};
+})();
 
 function logError(error) {
 	error = error || {};
@@ -50,30 +62,45 @@ function logError(error) {
 	);
 }
 
-// Check for --quick parameter. Quick mode deploys to both enwiki and enwiki-beta, without prompting for any info
+// Check for --quick parameter. Quick mode deploys to both enwiki and enwiki-beta, without prompting for any info. Also used in gadget-deploy.
 const quick = process.argv.includes("--quick");
 const config = [];
 
 if (quick) {
-	config.push({
-		wiki: "en",
-		beta: "y",
-		userComment: "",
-		consoleMessage: "QUICK MODE: Using defaults (en, beta, blank edit summary, auto-continue)"
-	});
-	config.push({
-		wiki: "en",
-		beta: "n",
-		userComment: "",
-		consoleMessage: "QUICK MODE: Using defaults (en, main, blank edit summary, auto-continue)"
-	});
+	if (credentials.site) {
+		config.push({
+			apiUrl: credentials.site,
+			beta: "y",
+			userComment: "",
+			consoleMessage: "QUICK MODE: Using defaults (site from credentials.json, beta, blank edit summary, auto-continue)"
+		});
+		config.push({
+			apiUrl: credentials.site,
+			beta: "n",
+			userComment: "",
+			consoleMessage: "QUICK MODE: Using defaults (site from credentials.json, main, blank edit summary, auto-continue)"
+		});
+	} else {
+		config.push({
+			apiUrl: "https://en.wikipedia.org/w/api.php",
+			beta: "y",
+			userComment: "",
+			consoleMessage: "QUICK MODE: Using defaults (en, beta, blank edit summary, auto-continue)"
+		});
+		config.push({
+			apiUrl: "https://en.wikipedia.org/w/api.php",
+			beta: "n",
+			userComment: "",
+			consoleMessage: "QUICK MODE: Using defaults (en, main, blank edit summary, auto-continue)"
+		});
+	}
 } else {
 	// Prompt user for info
-	wiki = prompt("> Wikipedia subdomain: ");
-	beta = prompt("> Beta deployment [Y/n]: ");
-	userComment = prompt("> Edit summary message (optional): ");
+	const wiki = prompt("> Wikipedia subdomain: ");
+	const beta = prompt("> Beta deployment [Y/n]: ");
+	const userComment = prompt("> Edit summary message (optional): ");
 	config.push({
-		wiki: wiki,
+		apiUrl: `https://${wiki}.wikipedia.org/w/api.php`,
 		beta: beta,
 		userComment: userComment,
 		consoleMessage: null
@@ -83,7 +110,7 @@ if (quick) {
 
 async function deploy(config) {
 	for (let i = 0; i < config.length; i++) {
-		const wiki = config[i].wiki;
+		const apiUrl = config[i].apiUrl;
 		const beta = config[i].beta;
 		const userComment = config[i].userComment;
 		const consoleMessage = config[i].consoleMessage;
@@ -105,15 +132,18 @@ async function deploy(config) {
 			{file: "styles-gadget.css", target: `MediaWiki:Gadget-XFDcloser-core${isBeta ? "-beta" : ""}.css`}
 		];
 
-		const api = new mwn({
-			apiUrl: `https://${wiki}.wikipedia.org/w/api.php`,
-			username: username,
-			password: password
+		const api = await Mwn.init({
+			apiUrl: apiUrl,
+			username: credentials.username,
+			password: credentials.password,
+			OAuth2AccessToken: credentials.accessToken
 		});
 
-		console.log(`... logging in as ${username}  ...`);
+		if (credentials.username) {
+			console.log(`... logging in as ${credentials.username}  ...`);
+		}
+
 		try {
-			await api.loginGetToken();
 			if (!quick) {
 				prompt("> Press [Enter] to start deploying or [ctrl + C] to cancel");
 			}
@@ -125,9 +155,9 @@ async function deploy(config) {
 					const status = response && response.nochange
 						? "━ No change saving"
 						: "✔ Successfully saved";
-					console.log(`${status} ${deployment.file} to ${wiki}:${deployment.target}`);
+					console.log(`${status} ${deployment.file} to ${deployment.target}`);
 				} catch (error) {
-					console.log(`✘ Failed to save ${deployment.file} to ${wiki}:${deployment.target}`);
+					console.log(`✘ Failed to save ${deployment.file} to ${deployment.target}`);
 					logError(error);
 				}
 			}


### PR DESCRIPTION
* This allows the script to work with https://gadget-deploy.toolforge.org/, a three-click gadget GitHub-to-wiki deploy tool for interface administrators.
* Takes in the site value as apiUrl for the --quick mode, if it exists
* Update loading of credentials.json to a dictionary for better flexibility

Partially resolves #101
Related PR in gadget-deploy repo https://github.com/wikimedia-gadgets/gadget-deploy/pull/4
