### PR TITLE
DiscussionView: fix jQuery to not include "edit" links

### DIFF
--- a/xfdcloser-src/Views/DiscussionView.js
+++ b/xfdcloser-src/Views/DiscussionView.js
@@ -193,7 +193,9 @@ DiscussionView.newFromHeadline = function({headingIndex, context, venue, current
 		pages = $discussionNodes
 			.find("dd > ul > li")
 			.has("b:first-child:contains(\"Propose \")")
-			.find("a:first-of-type")
+			.find("span")
+			.not(".lx")
+			.children("a:first-of-type")
 			.not(".external")
 			.map(function () { return mw.Title.newFromText($(this).text()); })
 			.get();


### PR DESCRIPTION
Fix to issue #102, tested on [this testwiki CfD](https://test.wikipedia.org/wiki/Wikipedia:Categories_for_discussion/Log/2026_March_7) after updating its {{category links}} template.

The new jQuery expression I'm using (which isn't compatible with the previous change, meaning it won't work if other wikis decide to use it while having the old syntax) is the following:
```
$discussionNodes
	.find("dd > ul > li")
	.has("b:first-child:contains(\"Propose \")")
	.find("span")
	.not(".lx")
	.children("a:first-of-type")
	.not(".external")
```