### PR TITLE
AfD: update merge templates to named parameters

### DIFF
--- a/test/testTaskAddMergeTemplates.js
+++ b/test/testTaskAddMergeTemplates.js
@@ -75,7 +75,7 @@ describe("AddMergeTemplates", function() {
 			throw new Error("Transformation resulted in a promise");
 		}
 		assert.deepStrictEqual(transformed, {
-			text: `{{Afd-merge to|Qux|discussionName|${dmyDateString(dateNow)}}}\nLorem impsum`,
+			text: `{{Afd-merge to|Qux|discussion=discussionName|date=${dmyDateString(dateNow)}}}\nLorem impsum`,
 			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge " + config.script.advert
 		});
 	});
@@ -93,7 +93,7 @@ Lorem impsum`
 			throw new Error("Transformation resulted in a promise");
 		}
 		assert.deepStrictEqual(transformed, {
-			text: `{{Afd-merge to|Qux|discussionName|${dmyDateString(dateNow)}}}\nLorem impsum`,
+			text: `{{Afd-merge to|Qux|discussion=discussionName|date=${dmyDateString(dateNow)}}}\nLorem impsum`,
 			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge " + config.script.advert
 		});
 	});
@@ -137,7 +137,7 @@ Lorem impsum`
 			throw new Error("Transformation resulted in a promise");
 		}
 		assert.deepStrictEqual(transformed, {
-			prependtext: `{{Afd-merge from|Foo|discussionName|${dmyDateString(dateNow)}}}\n{{Afd-merge from|Bar|discussionName|${dmyDateString(dateNow)}}}\n`,
+			prependtext: `{{Afd-merge from|Foo|discussion=discussionName|date=${dmyDateString(dateNow)}}}\n{{Afd-merge from|Bar|discussionName|${dmyDateString(dateNow)}}}\n`,
 			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge " + config.script.advert
 		});
 	});

--- a/test/testTaskAddMergeTemplates.js
+++ b/test/testTaskAddMergeTemplates.js
@@ -137,7 +137,7 @@ Lorem impsum`
 			throw new Error("Transformation resulted in a promise");
 		}
 		assert.deepStrictEqual(transformed, {
-			prependtext: `{{Afd-merge from|Foo|discussion=discussionName|date=${dmyDateString(dateNow)}}}\n{{Afd-merge from|Bar|discussionName|${dmyDateString(dateNow)}}}\n`,
+			prependtext: `{{Afd-merge from|Foo|discussion=discussionName|date=${dmyDateString(dateNow)}}}\n{{Afd-merge from|Bar|discussion=discussionName|date=${dmyDateString(dateNow)}}}\n`,
 			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge " + config.script.advert
 		});
 	});

--- a/xfdcloser-src/Venue.js
+++ b/xfdcloser-src/Venue.js
@@ -288,8 +288,8 @@ Venue.Afd = transcludedOnly => new Venue("afd", {
 	wikitext: {
 		closeTop:		"{{subst:Afd top|'''__RESULT__'''}}__TO_TARGET____RATIONALE__ __SIG__",
 		closeBottom:	"{{subst:Afd bottom}}",
-		mergeFrom:		"{{Afd-merge from|__NOMINATED__|__DEBATE__|__DATE__}}\n",
-		mergeTo:		"{{Afd-merge to|__TARGET__|__DEBATE__|__DATE__}}\n",
+		mergeFrom:		"{{Afd-merge from|__NOMINATED__|discussion=__DEBATE__|date=__DATE__}}\n",
+		mergeTo:		"{{Afd-merge to|__TARGET__|discussion=__DEBATE__|date=__DATE__}}\n",
 		alreadyClosed:	"<!--Template:Afd bottom-->"		
 	},
 	regex: {


### PR DESCRIPTION
We are in the process of deprecating the unnamed parameters/altering their use case to align with the merger of WP:PAM into WP:AfD. This change is required for the process to move forward.
{{afd-merge to}}, {{afd-merge from}}, and {{afd-merged-from}} have all already been updated to support the named parameters.