### PR TITLE
Resolve false positives in edit conflict detector

### DIFF
--- a/test/testTaskCloseDiscussion.js
+++ b/test/testTaskCloseDiscussion.js
@@ -81,7 +81,7 @@ describe("CloseDiscussion", function() {
 			"Plain sub",
 			"Spacing",
 			"Uneven spacing",
-			"Multiple spaces",
+			"Multiple  spaces",
 			"Linked",
 			"Piped link",
 			"{{Linked template}}",

--- a/xfdcloser-src/Controllers/Tasks/CloseDiscussion.js
+++ b/xfdcloser-src/Controllers/Tasks/CloseDiscussion.js
@@ -25,7 +25,7 @@ export default class CloseDiscussion extends TaskItemController {
 			.replace(/\[\[:?(?:[^\]]+\|)?([^\]]+)\]\]/g, "$1") // replace link markup with link text
 			.replace(/{{\s*[Tt]l[a-z]?\s*\|\s*([^}]+)}}/g, "{{$1}}") // replace tl templates
 			.replace(/s*}}/, "}}") // remove any extra spaces after replacing tl templates
-			.replace(/\s{2,}/g, " ") // collapse multiple spaces into a single space
+			.replace(/'''?/g, "") // Remove italics and bold
 			.trim()
 		);
 	};


### PR DESCRIPTION
Resolves issue #137 as well as the newly reported issue with double spaces from [[Wikipedia talk:XFDcloser#Could not close discussion with italicized title]]. 

Ngl I don't fully understand what this check is trying to do but this edit resolves the issues for both italic and double spaced titles.