### PR TITLE
Fix confirmation window for adding oldrfd to redirects

### DIFF
--- a/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
+++ b/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
@@ -1,6 +1,6 @@
-import { $, mw, OO } from "../../../globals";
+import { $, mw} from "../../../globals";
 import TaskItemController from "../TaskItemController";
-import { rejection, dmyDateString, dateFromUserInput, uppercaseFirst, ymdDateString } from "../../util";
+import { rejection, dmyDateString, dateFromUserInput, uppercaseFirst, ymdDateString, multiButtonConfirm } from "../../util";
 import Template from "../../Template";
 // <nowiki>
 
@@ -166,17 +166,24 @@ export default class AddOldXfdTask extends TaskItemController {
 		switch(true) {
 		case page.redirect && this.model.venue.type === "rfd":
 			// Redirect at RfD: ask what to to do
-			return OO.ui.confirm(`"${page.title}" is currently a redirect. Okay to replace with Old RFD template?`)
-				.then( confirmed => {
-					if (!confirmed) {
-						return $.Deferred().reject("skipped");
-					}
-					return {
-						...baseEditParams,
-						text: this.makeOldxfdWikitext(),
-						redirect: false
-					};
-				} );
+			return multiButtonConfirm({title: "Warning",
+				message: `"${page.title}" is currently a redirect. Okay to replace with Old RFD template?`,
+				actions: [
+					{ label:"Do nothing", flags:"safe" },
+					{ label:"Overwrite redirect", action:"accept", flags:"progressive" }
+				],
+				size: "medium",
+				scrolled: true
+			}).then( confirmed => {
+				if (!confirmed) {
+					return $.Deferred().reject("skipped");
+				}
+				return {
+					...baseEditParams,
+					text: this.makeOldxfdWikitext(),
+					redirect: false
+				};
+			} );
 		case page.redirect && this.model.venue.type === "mfd":
 			// Redirect at MfD: edit the redirect's target page, using the altpage parameter
 			return {


### PR DESCRIPTION
Fixes #97 which in reality was triggered by trying to place the oldrfd template on a talk page which was a redirect itself. There was code for handling this using OO.ui.confirm to ask the user but it was broken. Switching to multiButtonConfirm like similar confirmations are done solved the issue. 