### PR TITLE
Improved queries for finding pages involved in CfD

### DIFF
--- a/xfdcloser-src/Views/DiscussionView.js
+++ b/xfdcloser-src/Views/DiscussionView.js
@@ -208,7 +208,6 @@ DiscussionView.newFromHeadline = function({headingIndex, context, venue, current
 			.map(function () { return mw.Title.newFromText($(this).text()); })
 			.get();
 		} 
-		console.log(pages)
 		// Try to find the proposed action
 		const $action = $heading
 			.next()

--- a/xfdcloser-src/Views/DiscussionView.js
+++ b/xfdcloser-src/Views/DiscussionView.js
@@ -192,24 +192,23 @@ DiscussionView.newFromHeadline = function({headingIndex, context, venue, current
 		//CFDs: Nominated pages are the first link of an <li> item in a <ul> list, within a <dl> list
 		pages = $discussionNodes
 			.find("dd > ul > li")
-			.has("b:first-child:contains(\"Propose \")")
-			.find("span")
-			.not(".lx")
-			.children("a:first-of-type")
+			.has("b:first-child")
+			.children("a:nth-child(2)")
+			.not(":has(span)")
 			.not(".external")
 			.map(function () { return mw.Title.newFromText($(this).text()); })
 			.get();
 		if (pages.length === 0) {
-			// Sometimes nominated pages are instead just in a <ul> list, e.g.
-			// Wikipedia:Categories_for_discussion/Log/2019_February_5#Foo_in_fiction
-			pages = $heading
-				.next("ul")
-				.find("li")
-				.find("a:first-of-type")
-				.not(".external")
-				.map(function () { return mw.Title.newFromText($(this).text()); })
-				.get();
-		}
+			pages = $discussionNodes
+			.find("dd > ul > li")
+			.has("b:first-child")
+			.children("span") // If using {{Lc}} there's an extra span
+			.children("a:first-of-type")
+			.not(".external")
+			.map(function () { return mw.Title.newFromText($(this).text()); })
+			.get();
+		} 
+		console.log(pages)
 		// Try to find the proposed action
 		const $action = $heading
 			.next()

--- a/xfdcloser-src/Views/DiscussionView.js
+++ b/xfdcloser-src/Views/DiscussionView.js
@@ -202,7 +202,7 @@ DiscussionView.newFromHeadline = function({headingIndex, context, venue, current
 			pages = $discussionNodes
 			.find("dd > ul > li")
 			.has("b:first-child")
-			.children("span") // If using {{Lc}} there's an extra span
+			.children("span:nth-child(2)") // If using {{Lc}} there's an extra span
 			.children("a:first-of-type")
 			.not(".external")
 			.map(function () { return mw.Title.newFromText($(this).text()); })

--- a/xfdcloser-src/Views/DiscussionView.js
+++ b/xfdcloser-src/Views/DiscussionView.js
@@ -200,13 +200,13 @@ DiscussionView.newFromHeadline = function({headingIndex, context, venue, current
 			.get();
 		if (pages.length === 0) {
 			pages = $discussionNodes
-			.find("dd > ul > li")
-			.has("b:first-child")
-			.children("span:nth-child(2)") // If using {{Lc}} there's an extra span
-			.children("a:first-of-type")
-			.not(".external")
-			.map(function () { return mw.Title.newFromText($(this).text()); })
-			.get();
+				.find("dd > ul > li")
+				.has("b:first-child")
+				.children("span:nth-child(2)") // If using {{Lc}} there's an extra span
+				.children("a:first-of-type")
+				.not(".external")
+				.map(function () { return mw.Title.newFromText($(this).text()); })
+				.get();
 		} 
 		// Try to find the proposed action
 		const $action = $heading


### PR DESCRIPTION
Resolves #80, resolves #78, resolves #73 all of which stem from the detection of which pages are nominated being severely broken. 

The detection algorithm consist of two parts one for detecting nomination without a template and a second for nomination using a template. The former was overly strict requiring the action to be preceded by "Propose" which caused many nominations to use the way too loose second query. (#78 and #80) By requiring the link to be the second child we ensure we don't include spurious merge targets as before even if there's a mix of links with and without spans. 

Testing was done mostly by checking that all 28 discussions posted yesterday parsed correctly which wasn't the case with the old detection system at all. 
