### PR TITLE
Add to CFDW action

### DIFF
--- a/xfdcloser-src/Controllers/Tasks/AddToCfdw.js
+++ b/xfdcloser-src/Controllers/Tasks/AddToCfdw.js
@@ -1,0 +1,116 @@
+import { mw } from "../../../globals";
+import { rejection, makeLink } from "../../util";
+import TaskItemController from "../TaskItemController";
+// <nowiki>
+
+export default class AddToCfdw extends TaskItemController {
+	constructor(model, widgets) {
+		super(model, widgets);
+		this.model.setName("Listing at working page");
+	}
+
+	/**
+	 * Remove `* ''None currently''` except if inside a <!--html comment-->, and trim
+	 * 
+	 * @param {String} wikitext section wikitext
+	 * @returns {String} cleaned-up section wikitext
+	 */
+	static cleanupSection = wikitext => wikitext.replace(/\n*^\*\s*''None currently''\s*$(?![^<]*?-->)/gim, "").trim();
+
+	transform(workingPage) {
+		if ( this.model.aborted ) return rejection("aborted");
+		// Get page contents, split into section
+		const sectionsArray = workingPage.content.split(/\n={2,}/).map(section => {
+			const headingSigns = /^[^=]+(=+)\n/.exec(section);
+			if (!headingSigns) {
+				return section;
+			}
+			return headingSigns[1] + section;
+		});
+		const header = "\n; [["+ this.model.discussion.discussionPageLink+"]]";
+		let changesMade = 0;
+		let sectionHeader = {};
+		this.model.getPageResults().forEach(pageResult => {
+			console.log(pageResult);
+			const pageName = this.model.discussion.redirects.resolveOne(pageResult.pageName);
+			const pageTitle = mw.Title.newFromText(pageName);
+			const result = pageResult.selectedResultName;
+			const sectionNum = this.model.venue.workingPageSectionNumber[result];
+			const options = this.model.options.getOptionValues(pageResult.selectedResultName);
+			const hasCorrectNamespace = this.model.venue.ns_number.includes(pageTitle.getNamespaceId());
+			// Check namespace and existance
+			if ( !hasCorrectNamespace ) {
+				this.model.addError(
+					`${makeLink(pageName)} is not in the expected namespace, and will not be listed at the holding cell`
+				);
+				return;
+			} else if ( !pageTitle.exists() ) {
+				this.model.addError(
+					`${makeLink(pageName)} does not exist, and will not be listed at the holding cell`
+				);
+				return;
+			}
+			if (!sectionHeader[result]) {
+				sectionHeader[result] = true;
+				sectionsArray[sectionNum] = AddToCfdw.cleanupSection(sectionsArray[sectionNum]) + header;
+			}
+			console.log(options);
+			let row;
+			if (options.leaveRedirect || options.action === "cfdwRedirect") {
+				row = "* REDIRECT ";
+			} else {
+				row = "* ";
+			}
+			row += "[[:" + pageName + "]]";
+			if (pageResult.selectedResultName != "delete") {
+				row += " to [[:" + pageResult.targetPageName + "]]";
+			}
+			// Make new section wikitext
+			sectionsArray[sectionNum] = AddToCfdw.cleanupSection(sectionsArray[sectionNum]) + "\n" + row;
+			changesMade++;
+		});
+
+		if ( changesMade === 0 ) {
+			return rejection("noChangesMade");
+		}
+
+		return {
+			text: sectionsArray.join("\n"),
+			summary: this.model.getEditSummary({prefix: "Listing category:"})
+		};
+	}
+
+	doTask = function() {
+		this.model.setTotalSteps(1);
+		this.model.setDoing();
+		return this.api.queryWithContinue({
+			titles: this.model.getResolvedPageNames(),
+			prop: "categoryinfo"
+		}).then(response => {
+			if ( this.model.aborted ) {
+				return rejection("aborted");
+			} else if ( !response ) {
+				this.model.addWarning("No categories found");
+				return rejection("Skipped.");
+			}
+			return response.pages.map(page => {return page.categoryinfo.size;}).reduce((acc, num) => acc + num, 0);
+		}).then(totalEdits => {
+			let subpageName = "Working";
+			if (totalEdits >= 5000) {
+				subpageName = "Working/Large";
+			}
+			return subpageName;
+		}).then(subpageName =>{
+			return this.api.editWithRetry(
+				"Wikipedia:Categories for discussion/" + subpageName,
+				null,
+				page => this.transform(page),
+				() => this.model.trackStep(),
+				(code, error, title) => this.handlePageError(code, error, title)
+			).catch(
+				(errortype, code, error) => this.handleOverallError(errortype, code, error)
+			);}
+		);
+	};
+}
+// </nowiki>

--- a/xfdcloser-src/Controllers/Tasks/AddToCfdw.js
+++ b/xfdcloser-src/Controllers/Tasks/AddToCfdw.js
@@ -31,7 +31,6 @@ export default class AddToCfdw extends TaskItemController {
 		let changesMade = 0;
 		let sectionHeader = {};
 		this.model.getPageResults().forEach(pageResult => {
-			console.log(pageResult);
 			const pageName = this.model.discussion.redirects.resolveOne(pageResult.pageName);
 			const pageTitle = mw.Title.newFromText(pageName);
 			const result = pageResult.selectedResultName;
@@ -54,7 +53,6 @@ export default class AddToCfdw extends TaskItemController {
 				sectionHeader[result] = true;
 				sectionsArray[sectionNum] = AddToCfdw.cleanupSection(sectionsArray[sectionNum]) + header;
 			}
-			console.log(options);
 			let row;
 			if (options.leaveRedirect || options.action === "cfdwRedirect") {
 				row = "* REDIRECT ";
@@ -67,6 +65,7 @@ export default class AddToCfdw extends TaskItemController {
 			}
 			// Make new section wikitext
 			sectionsArray[sectionNum] = AddToCfdw.cleanupSection(sectionsArray[sectionNum]) + "\n" + row;
+			sectionsArray[sectionNum] = sectionsArray[sectionNum].replace(/(<!--\s*End of list[^>]*-->)(.*)/si, "$2\n$1\n")
 			changesMade++;
 		});
 
@@ -97,7 +96,7 @@ export default class AddToCfdw extends TaskItemController {
 		}).then(totalEdits => {
 			let subpageName = "Working";
 			if (totalEdits >= 5000) {
-				subpageName = "Working/Large";
+				return rejection("This category belongs at WP:CFDWL since over 5000 pages will be affected. Please add it there manually");
 			}
 			return subpageName;
 		}).then(subpageName =>{

--- a/xfdcloser-src/Controllers/Tasks/AddToCfdw.js
+++ b/xfdcloser-src/Controllers/Tasks/AddToCfdw.js
@@ -65,7 +65,7 @@ export default class AddToCfdw extends TaskItemController {
 			}
 			// Make new section wikitext
 			sectionsArray[sectionNum] = AddToCfdw.cleanupSection(sectionsArray[sectionNum]) + "\n" + row;
-			sectionsArray[sectionNum] = sectionsArray[sectionNum].replace(/(<!--\s*End of list[^>]*-->)(.*)/si, "$2\n$1\n")
+			sectionsArray[sectionNum] = sectionsArray[sectionNum].replace(/(<!--\s*End of list[^>]*-->)(.*)/si, "$2\n$1\n");
 			changesMade++;
 		});
 

--- a/xfdcloser-src/Controllers/Tasks/AddToHoldingCell.js
+++ b/xfdcloser-src/Controllers/Tasks/AddToHoldingCell.js
@@ -42,7 +42,7 @@ export default class AddToHoldingCell extends TaskItemController {
 	};
 
 	transform(holdingCellPage) {
-		if ( this.model.aborted ) return rejection("aorted");
+		if ( this.model.aborted ) return rejection("aborted");
 		// Get page contents, split into section
 		const sectionsArray = holdingCellPage.content.split(/\n={3,}/).map(section => {
 			const headingSigns = /^[^=]+(=+)\n/.exec(section);

--- a/xfdcloser-src/Models/TaskList.js
+++ b/xfdcloser-src/Models/TaskList.js
@@ -263,6 +263,25 @@ class TaskList {
 			}
 		}
 
+		// CFDW
+		const cfdwPageResults = resultsbyPage.filter(result => {
+			const optionValues = this.options.getOptionValues(result.selectedResultName);
+			const action = optionValues && optionValues.action;
+			return action === "cfdw" || action === "cfdwRedirect";
+		});
+		if (cfdwPageResults.length) {
+			tasks.push(
+				new TaskItem({
+					taskName: "AddToCfdw",
+					relaventPageNames: cfdwPageResults.map(result => result.pageName),
+					discussion: this.discussion,
+					result: this.result,
+					options: this.options
+				})
+			);
+		}
+		
+
 		tasks.slice(1).forEach(task => {
 			if ( !task.precedingTask ) {
 				task.setPrecedingTask(closeDiscussionTask, "done");

--- a/xfdcloser-src/Venue.js
+++ b/xfdcloser-src/Venue.js
@@ -99,7 +99,13 @@ Venue.Cfd = () => {
 			nomTemplate:	/<!--\s*BEGIN CFD TEMPLATE\s*-->(?:.|\n)+<!--\s*END CFD TEMPLATE\s*-->\n*/gi,
 			relistPattern:	/ full\|day=\d\d?\|month=\w+\|year=\d{4}/gi
 		},
-		relistTasks:		["UpdateOldLogPage", "UpdateNewLogPage", "UpdateNomTemplates"]
+		relistTasks:		["UpdateOldLogPage", "UpdateNewLogPage", "UpdateNomTemplates"],
+		workingPageSectionNumber: {
+			"rename":		6,
+			"merge":		7,
+			"delete":		8,
+			"redirect":		8,
+		},
 	});
 	// Override prototype
 	cfdVenue.updateNomTemplateAfterRelist = function(wikitext, today, /*_sectionHeader*/) {

--- a/xfdcloser-src/Views/TaskItemWidget.js
+++ b/xfdcloser-src/Views/TaskItemWidget.js
@@ -2,6 +2,7 @@ import { OO } from "../../globals";
 import AddBeingDeleted from "../Controllers/Tasks/AddBeingDeleted";
 import AddMergeTemplates from "../Controllers/Tasks/AddMergeTemplates";
 import AddOldXfd from "../Controllers/Tasks/AddOldXfd";
+import AddToCfdw from "../Controllers/Tasks/AddToCfdw";
 import AddToHoldingCell from "../Controllers/Tasks/AddToHoldingCell";
 import CloseDiscussion from "../Controllers/Tasks/CloseDiscussion";
 import DeletePages from "../Controllers/Tasks/DeletePages";
@@ -21,7 +22,7 @@ import UpdateOldLogPage from "../Controllers/Tasks/UpdateOldLogPage";
 // <nowiki>
 
 const controllers = {
-	AddBeingDeleted, AddMergeTemplates, AddOldXfd, AddToHoldingCell, CloseDiscussion, DeletePages,
+	AddBeingDeleted, AddMergeTemplates, AddOldXfd, AddToCfdw, AddToHoldingCell, CloseDiscussion, DeletePages,
 	DeleteRedirects, DeleteTalkpages, Disambiguate, GetRelistInfo, Redirect, RemoveCircularLinks,
 	RemoveNomTemplates,	TagTalkWithSpeedy, UnlinkBacklinks, UpdateDiscussion, UpdateNewLogPage,
 	UpdateNomTemplates, UpdateOldLogPage

--- a/xfdcloser-src/data.js
+++ b/xfdcloser-src/data.js
@@ -24,15 +24,27 @@ const resultsData = [
 		venues: ["afd", "ffd", "mfd", "rfd"],
 		actions: ["deletePages", "noActions"]
 	},
-	// Delete (CFD)
+	// Delete (non-sysop CFD)
 	{
 		name: "delete",
 		label: "Delete",
 		title: "Close discussion as \"delete\"",
 		allowSpeedy: true,
 		allowSoft: true,
+		nonSysopOnly: true,
 		venues: ["cfd"],
 		actions: ["noActions"]
+	},
+	// Delete (sysop CFD)
+	{
+		name: "delete",
+		label: "Delete",
+		title: "Close discussion as \"delete\"",
+		allowSpeedy: true,
+		allowSoft: true,
+		sysopOnly: true,
+		venues: ["cfd"],
+		actions: ["cfdw", "noActions"]
 	},
 	// Delete (sysop, TFD)
 	{
@@ -80,14 +92,25 @@ const resultsData = [
 		venues: ["afd", "mfd"],
 		actions: ["redirectAndUpdate", "noActions"]
 	},
-	// Redirect (CFD)
+	// Redirect (non-sysop CFD)
 	{
 		name: "redirect",
 		label: "Redirect",
 		title: "Close discussion as \"redirect\"",
 		requireTarget: true,
+		nonSysopOnly: true,
 		venues: ["cfd"],
 		actions: ["noActions"]
+	},
+	// Redirect (sysop CFD)
+	{
+		name: "redirect",
+		label: "Redirect",
+		title: "Close discussion as \"redirect\"",
+		requireTarget: true,
+		sysopOnly: true,
+		venues: ["cfd"],
+		actions: ["cfdwRedirect", "noActions"]
 	},
 	// Redirect (sysop, TFD)
 	{
@@ -111,14 +134,26 @@ const resultsData = [
 		actions: ["redirectAndUpdate", "noActions"]
 	},
 
-	// Rename (CFD)
+	// Rename (non-sysop CFD)
 	{
 		name: "rename",
 		label: "Rename",
 		title: "Close discussion as \"rename\"",
 		requireTarget: true,
+		nonSysopOnly: true,
 		venues: ["cfd"],
 		actions: ["noActions"]
+	},
+
+	// Rename (non-sysop CFD)
+	{
+		name: "rename",
+		label: "Rename",
+		title: "Close discussion as \"rename\"",
+		requireTarget: true,
+		sysopOnly: true,
+		venues: ["cfd"],
+		actions: ["cfdw", "noActions"]
 	},
 
 	// Retarget (sysop, RFD)
@@ -184,14 +219,25 @@ const resultsData = [
 		venues: ["mfd"],
 		actions: ["mergeAndUpdate", "noActions"]
 	},
-	// Merge (CFD)
+	// Merge (non-sysop CFD)
 	{
 		name: "merge",
 		label: "Merge",
 		title: "Close discussion as \"merge\"",
 		requireTarget: true,
+		nonSysopOnly: true,
 		venues: ["cfd"],
 		actions: ["noActions"]
+	},	
+	// Merge (sysop CFD)
+	{
+		name: "merge",
+		label: "Merge",
+		title: "Close discussion as \"merge\"",
+		requireTarget: true,
+		sysopOnly: true,
+		venues: ["cfd"],
+		actions: ["cfdw", "noActions"]
 	},
 	// Merge (TFD)
 	{
@@ -491,6 +537,15 @@ const actions = [
 		name: "mergeAndUpdate"
 	},
 	{
+		label: "List at working page",
+		name: "cfdw",
+		options: ["leaveRedirect"]
+	},
+	{
+		label: "List at working page",
+		name: "cfdwRedirect"
+	},
+	{
 		label: "No automated actions",
 		name: "noActions",
 	}
@@ -571,6 +626,14 @@ const options = [
 		venues: ["afd"],
 		items: rcats,
 		value: ["{{R to related topic}}"]
+	},
+	{
+		name: "leaveRedirect",
+		label: "Leave redirect",
+		type: "toggleSwitch",
+		for: "cfdw",
+		venues: ["cfd"],
+		value: false // initial value
 	}
 ];
 


### PR DESCRIPTION
CFD closes currently only remove nomination templates and tag talk pages while doing nothing else. This pull request adds the "List at working page" action for admins which adds deletes, moves, redirects and mergers at CFDW as appropriate. For large queries requiring CFDWL (over 5000 pages) it throws an error currently but that behaviour could be changed. 