### PR TITLE
Add target to Merge and redirect closes

### DIFF
--- a/test/testTaskAddBeingDeleted.js
+++ b/test/testTaskAddBeingDeleted.js
@@ -127,7 +127,7 @@ describe("AddBeingDeleted", function() {
 			transformed,
 			{
 				text: "blah blah blah",
-				summary: "[[WP:TFD/discussionPageName#Foo and bar]] closed as merge " + config.script.advert
+				summary: "[[WP:TFD/discussionPageName#Foo and bar]] closed as merge into [[Template:Foo]] " + config.script.advert
 			}
 		);
 	});

--- a/test/testTaskAddMergeTemplates.js
+++ b/test/testTaskAddMergeTemplates.js
@@ -76,7 +76,7 @@ describe("AddMergeTemplates", function() {
 		}
 		assert.deepStrictEqual(transformed, {
 			text: `{{Afd-merge to|Qux|discussion=discussionName|date=${dmyDateString(dateNow)}}}\nLorem impsum`,
-			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge " + config.script.advert
+			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge into [[Qux]] " + config.script.advert
 		});
 	});
 	it("transformNominatedPage replaces nomination template with mergeTo template", function() {
@@ -94,7 +94,7 @@ Lorem impsum`
 		}
 		assert.deepStrictEqual(transformed, {
 			text: `{{Afd-merge to|Qux|discussion=discussionName|date=${dmyDateString(dateNow)}}}\nLorem impsum`,
-			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge " + config.script.advert
+			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge into [[Qux]] " + config.script.advert
 		});
 	});
 	it("transformNominatedPage does not edit unexpected page", function() {
@@ -138,7 +138,7 @@ Lorem impsum`
 		}
 		assert.deepStrictEqual(transformed, {
 			prependtext: `{{Afd-merge from|Foo|discussion=discussionName|date=${dmyDateString(dateNow)}}}\n{{Afd-merge from|Bar|discussion=discussionName|date=${dmyDateString(dateNow)}}}\n`,
-			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge " + config.script.advert
+			summary: "[[Wikipedia:Articles for deletion/discussionName]] closed as merge into [[Qux]] " + config.script.advert
 		});
 	});
 	it("transformTargetTalk does not edit unexpected target page", function() {

--- a/test/testTaskAddOldXfd.js
+++ b/test/testTaskAddOldXfd.js
@@ -83,7 +83,7 @@ describe("AddBeingDeleted", function() {
 	it("makes old xfd wikitext", function() {
 		assert.deepStrictEqual(
 			task.makeOldxfdWikitext(),
-			"{{oldtfdfull|date= 18 March 2020 |result=merge into [[Template:Qux]] |disc=Foo and bar}}\n"
+			"{{oldtfdfull|date= 18 March 2020 |result='''merge''' into [[Template:Qux]] |disc=Foo and bar}}\n"
 		);
 	});
 	it("makes new wikitext (no page content)", function() {
@@ -106,7 +106,7 @@ describe("AddBeingDeleted", function() {
 		assert.strictEqual(
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=18 June 2019 |result1='''Keep''' |page1=" +page1 +
-				" |date2=18 March 2020 |result2='''Merge into [[Template:Qux]]''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\n"
+				" |date2=18 March 2020 |result2='''Merge''' into [[Template:Qux]] |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\n"
 		);
 	});
 	it("makes new wikitext (1 old TFD banner and other content)", function() {
@@ -117,7 +117,7 @@ describe("AddBeingDeleted", function() {
 		assert.strictEqual(
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=18 June 2019 |result1='''Keep''' |page1=" +page1 +
-				" |date2=18 March 2020 |result2='''Merge into [[Template:Qux]]''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
+				" |date2=18 March 2020 |result2='''Merge''' into [[Template:Qux]] |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
 		);
 	});
 	it("makes new wikitext (Old Afd multi)", function() {
@@ -125,7 +125,7 @@ describe("AddBeingDeleted", function() {
 		assert.strictEqual(
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=2010 February 26 |result1='''Redirect to [[Template:Abbr]]''' |link1={{canonicalurl:Wikipedia:Templates for discussion/Log/2010 February 26#Template:Tooltip}}"+
-				" |date2=18 March 2020 |result2='''Merge into [[Template:Qux]]''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}"
+				" |date2=18 March 2020 |result2='''Merge''' into [[Template:Qux]] |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}"
 		);
 	});
 	it("makes new wikitext (Old Afd multi and old TFD banner)", function() {
@@ -137,7 +137,7 @@ describe("AddBeingDeleted", function() {
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=2010 February 26 |result1='''Redirect to [[Template:Abbr]]''' |link1={{canonicalurl:Wikipedia:Templates for discussion/Log/2010 February 26#Template:Tooltip}}"+
 				" |date2=18 June 2019 |result2='''Keep''' |page2=" + page2 +
-				" |date3=18 March 2020 |result3='''Merge into [[Template:Qux]]''' |page3=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
+				" |date3=18 March 2020 |result3='''Merge''' into [[Template:Qux]] |page3=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
 		);
 	});
 	it("transforms a page with content", function() {

--- a/test/testTaskAddOldXfd.js
+++ b/test/testTaskAddOldXfd.js
@@ -75,7 +75,7 @@ describe("AddBeingDeleted", function() {
 			options
 		});
 		task = new AddOldXfd(model, widgets);
-		summary = "[[Wikipedia:Templates for discussion/2020 March 18#Foo and bar]] closed as merge " + config.script.advert;
+		summary = "[[Wikipedia:Templates for discussion/2020 March 18#Foo and bar]] closed as merge into [[Template:Qux]] " + config.script.advert;
 	});
 	it("beforeEach is ok", function() {
 		assert.ok(true);
@@ -83,7 +83,7 @@ describe("AddBeingDeleted", function() {
 	it("makes old xfd wikitext", function() {
 		assert.deepStrictEqual(
 			task.makeOldxfdWikitext(),
-			"{{oldtfdfull|date= 18 March 2020 |result=merge |disc=Foo and bar}}\n"
+			"{{oldtfdfull|date= 18 March 2020 |result=merge into [[Template:Qux]] |disc=Foo and bar}}\n"
 		);
 	});
 	it("makes new wikitext (no page content)", function() {
@@ -106,7 +106,7 @@ describe("AddBeingDeleted", function() {
 		assert.strictEqual(
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=18 June 2019 |result1='''Keep''' |page1=" +page1 +
-				" |date2=18 March 2020 |result2='''Merge''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\n"
+				" |date2=18 March 2020 |result2='''Merge into [[Template:Qux]]''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\n"
 		);
 	});
 	it("makes new wikitext (1 old TFD banner and other content)", function() {
@@ -117,7 +117,7 @@ describe("AddBeingDeleted", function() {
 		assert.strictEqual(
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=18 June 2019 |result1='''Keep''' |page1=" +page1 +
-				" |date2=18 March 2020 |result2='''Merge''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
+				" |date2=18 March 2020 |result2='''Merge into [[Template:Qux]]''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
 		);
 	});
 	it("makes new wikitext (Old Afd multi)", function() {
@@ -125,7 +125,7 @@ describe("AddBeingDeleted", function() {
 		assert.strictEqual(
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=2010 February 26 |result1='''Redirect to [[Template:Abbr]]''' |link1={{canonicalurl:Wikipedia:Templates for discussion/Log/2010 February 26#Template:Tooltip}}"+
-				" |date2=18 March 2020 |result2='''Merge''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}"
+				" |date2=18 March 2020 |result2='''Merge into [[Template:Qux]]''' |page2=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}"
 		);
 	});
 	it("makes new wikitext (Old Afd multi and old TFD banner)", function() {
@@ -137,7 +137,7 @@ describe("AddBeingDeleted", function() {
 			task.makeNewWikitext(wikitext, "Template talk:Foo"),
 			"{{Old AfD multi |date1=2010 February 26 |result1='''Redirect to [[Template:Abbr]]''' |link1={{canonicalurl:Wikipedia:Templates for discussion/Log/2010 February 26#Template:Tooltip}}"+
 				" |date2=18 June 2019 |result2='''Keep''' |page2=" + page2 +
-				" |date3=18 March 2020 |result3='''Merge''' |page3=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
+				" |date3=18 March 2020 |result3='''Merge into [[Template:Qux]]''' |page3=Wikipedia:Templates for discussion/2020 March 18#Foo and bar}}\nLoremipsum"
 		);
 	});
 	it("transforms a page with content", function() {

--- a/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
+++ b/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
@@ -21,7 +21,7 @@ export default class AddOldXfdTask extends TaskItemController {
 			.replace(/__DATE_YMD__/, ymdDateString(this.model.discussion.nominationDate))
 			.replace(/__ACTION__/, this.model.discussion.action)
 			.replace(/__SECTION__/, this.model.discussion.sectionHeader)
-			.replace(/__RESULT__/, this.model.result.getResultTextWithTarget())
+			.replace(/__RESULT__/, ("'''" + this.model.result.getResultText() + "''' " + this.model.result.getFormattedTargetWithPreposition()).trim())
 			.replace(/__FIRSTDATE__/, dmyDateString(this.model.discussion.firstCommentDate))
 			.replace(/__SUBPAGE__/, this.model.discussion.discussionSubpageName);
 		if ( altpage ) {
@@ -122,15 +122,13 @@ export default class AddOldXfdTask extends TaskItemController {
 		// Otherwise, add current discussion to oldafdmulti
 		count++;
 		const currentCount = count === 1 ? "" : count.toString();
-		const currentResult = count === 1
-			? this.model.result.getResultTextWithTarget()
-			: uppercaseFirst(this.model.result.getResultTextWithTarget());
+		const currentResult = ("'''"+uppercaseFirst(this.model.result.getResultText()) + "''' " + this.model.result.getFormattedTargetWithPreposition()).trim();
 
 		const page = this.model.venue.type === "afd"
 			? this.model.discussion.discussionSubpageName
 			: this.model.discussion.discussionPageLink;
 			
-		oldafdmulti += ` |date${currentCount}=${dmyDateString(this.model.discussion.nominationDate)} |result${currentCount}='''${currentResult}''' |page${currentCount}=${page}}}`;
+		oldafdmulti += ` |date${currentCount}=${dmyDateString(this.model.discussion.nominationDate)} |result${currentCount}=${currentResult} |page${currentCount}=${page}}}`;
 
 		if ( oldAfdTemplate ) {
 			// Override the existing oldafdmulti

--- a/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
+++ b/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
@@ -122,7 +122,9 @@ export default class AddOldXfdTask extends TaskItemController {
 		// Otherwise, add current discussion to oldafdmulti
 		count++;
 		const currentCount = count === 1 ? "" : count.toString();
-		const currentResult = ("'''"+uppercaseFirst(this.model.result.getResultText()) + "''' " + this.model.result.getFormattedTargetWithPreposition()).trim();
+		const currentResult = count === 1
+			? ("'''"+this.model.result.getResultText() + "''' " + this.model.result.getFormattedTargetWithPreposition()).trim()
+			: ("'''"+uppercaseFirst(this.model.result.getResultText()) + "''' " + this.model.result.getFormattedTargetWithPreposition()).trim();
 
 		const page = this.model.venue.type === "afd"
 			? this.model.discussion.discussionSubpageName

--- a/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
+++ b/xfdcloser-src/Controllers/Tasks/AddOldXfd.js
@@ -21,7 +21,7 @@ export default class AddOldXfdTask extends TaskItemController {
 			.replace(/__DATE_YMD__/, ymdDateString(this.model.discussion.nominationDate))
 			.replace(/__ACTION__/, this.model.discussion.action)
 			.replace(/__SECTION__/, this.model.discussion.sectionHeader)
-			.replace(/__RESULT__/, this.model.result.getResultText())
+			.replace(/__RESULT__/, this.model.result.getResultTextWithTarget())
 			.replace(/__FIRSTDATE__/, dmyDateString(this.model.discussion.firstCommentDate))
 			.replace(/__SUBPAGE__/, this.model.discussion.discussionSubpageName);
 		if ( altpage ) {
@@ -123,8 +123,8 @@ export default class AddOldXfdTask extends TaskItemController {
 		count++;
 		const currentCount = count === 1 ? "" : count.toString();
 		const currentResult = count === 1
-			? this.model.result.getResultText()
-			: uppercaseFirst(this.model.result.getResultText());
+			? this.model.result.getResultTextWithTarget()
+			: uppercaseFirst(this.model.result.getResultTextWithTarget());
 
 		const page = this.model.venue.type === "afd"
 			? this.model.discussion.discussionSubpageName

--- a/xfdcloser-src/Models/Result.js
+++ b/xfdcloser-src/Models/Result.js
@@ -225,6 +225,16 @@ class Result {
 	// Alias
 	getResultText() { return this.getFormattedResult(); }
 
+	getFormattedResultWithTarget() {
+		if ( this.isMultimode ) {
+			return this.resultSummary.trim();
+		} else {
+			return this.singleModeResult.getResultTextWithTarget();
+		}
+	}
+	// Alias
+	getResultTextWithTarget() { return this.getFormattedResultWithTarget(); }
+
 	/**
 	 * @inheritdoc ResultItem.getFormattedTarget
 	 */

--- a/xfdcloser-src/Models/Result.js
+++ b/xfdcloser-src/Models/Result.js
@@ -225,21 +225,20 @@ class Result {
 	// Alias
 	getResultText() { return this.getFormattedResult(); }
 
-	getFormattedResultWithTarget() {
-		if ( this.isMultimode ) {
-			return this.resultSummary.trim();
-		} else {
-			return this.singleModeResult.getResultTextWithTarget();
-		}
-	}
-	// Alias
-	getResultTextWithTarget() { return this.getFormattedResultWithTarget(); }
 
 	/**
 	 * @inheritdoc ResultItem.getFormattedTarget
 	 */
 	getFormattedTarget(format) {
 		return this.isMultimode ? "" : this.singleModeResult.getFormattedTarget(format);
+	}
+
+	getFormattedTargetWithPreposition() {
+		if ( this.isMultimode ) {
+			return "";
+		} else {
+			return this.singleModeResult.getFormattedTargetWithPreposition();
+		}
 	}
 
 	getResultsByPage() {

--- a/xfdcloser-src/Models/ResultItem.js
+++ b/xfdcloser-src/Models/ResultItem.js
@@ -132,6 +132,17 @@ class ResultItem {
 		return ( prefix || "" ) + this.selectedResultName + suffix;
 	}
 
+	getResultTextWithTarget() {
+		if ( !this.selectedResult ) {
+			return "";
+		} else if ( this.selectedResult.name === "custom") {
+			return this.customResultText.trim();
+		}
+		const destination = ((this.selectedResult.name === "merge") && (" into [[" + this.targetPageName.charAt(0).toUpperCase() + this.targetPageName.slice(1) + "]]")) ||
+							((this.selectedResult.name === "redirect") && (" to [[" + this.targetPageName.charAt(0).toUpperCase() + this.targetPageName.slice(1) + "]]"));
+		return this.getResultText() + (destination || ""); 
+	}
+
 	/**
 	 * Target page formatted as a wikilink (default), or for "raw" format just
 	 * the page name and fragment (transformed by mw.Title's text function).

--- a/xfdcloser-src/Models/ResultItem.js
+++ b/xfdcloser-src/Models/ResultItem.js
@@ -132,15 +132,15 @@ class ResultItem {
 		return ( prefix || "" ) + this.selectedResultName + suffix;
 	}
 
-	getResultTextWithTarget() {
+	getFormattedTargetWithPreposition() {
 		if ( !this.selectedResult ) {
 			return "";
 		} else if ( this.selectedResult.name === "custom") {
 			return this.customResultText.trim();
 		}
-		const destination = ((this.selectedResult.name === "merge") && (" into [[" + this.targetPageName.charAt(0).toUpperCase() + this.targetPageName.slice(1) + "]]")) ||
-							((this.selectedResult.name === "redirect") && (" to [[" + this.targetPageName.charAt(0).toUpperCase() + this.targetPageName.slice(1) + "]]"));
-		return this.getResultText() + (destination || ""); 
+		const destination = ((this.selectedResult.name === "merge") && ("into [[" + this.targetPageName.charAt(0).toUpperCase() + this.targetPageName.slice(1) + "]]")) ||
+							((this.selectedResult.name === "redirect") && ("to [[" + this.targetPageName.charAt(0).toUpperCase() + this.targetPageName.slice(1) + "]]"));
+		return (destination || ""); 
 	}
 
 	/**

--- a/xfdcloser-src/Models/TaskItem.js
+++ b/xfdcloser-src/Models/TaskItem.js
@@ -124,7 +124,7 @@ class TaskItem {
 			// Deleting talk pages using CSD G8
 			? `[[${link}]]`
 			// Closing XFDs
-			: `[[${link}]] closed as ${this.result.getResultText()}`;
+			: `[[${link}]] closed as ${this.result.getResultTextWithTarget()}`;
 		return prefix + main + " " + appConfig.script.advert;
 	}
 

--- a/xfdcloser-src/Models/TaskItem.js
+++ b/xfdcloser-src/Models/TaskItem.js
@@ -124,7 +124,7 @@ class TaskItem {
 			// Deleting talk pages using CSD G8
 			? `[[${link}]]`
 			// Closing XFDs
-			: `[[${link}]] closed as ${this.result.getResultTextWithTarget()}`;
+			: `[[${link}]] closed as ${this.result.getResultText() + " " + this.result.getFormattedTargetWithPreposition()}`.trim();
 		return prefix + main + " " + appConfig.script.advert;
 	}
 


### PR DESCRIPTION
Another box at #135. I decided to add this as a separate function to avoid breaking the rationale which already get the destination added elsewhere and potentially other places.  https://test.wikipedia.org/w/index.php?title=Talk:Mergetest1&diff=prev&oldid=747791 and https://test.wikipedia.org/w/index.php?title=Talk:Mergetest1&diff=prev&oldid=747787 demonstrates this working for summaries and old AFD text for both mergers and redirects for new and pre-existing old afd templates. 