### PR TITLE
Update data.js to remove invalid item

### DIFF
--- a/xfdcloser-src/data.js
+++ b/xfdcloser-src/data.js
@@ -551,7 +551,6 @@ const options = [
 			{label: "Merge (Infoboxes)", data:"merge-infobox"},
 			{label: "Merge (Navigation templates)", data:"merge-navigation"},
 			{label: "Merge (Link templates)", data:"merge-link"},
-			{label: "Merge (Sports)", data:"merge-sports"},
 			{label: "Merge (Other)", data:"merge-other"},
 			{label: "Merge (Meta)", data:"merge-meta"}
 		]


### PR DESCRIPTION
"Sports" hasn't been a valid option at TFDH since 2020, throws error if it's selected during a TFD close.