### PR TITLE
Look for level-2 headers in the TfD/Holding cell rather than level-3 headers

### DIFF
--- a/xfdcloser-src/Controllers/Tasks/AddToHoldingCell.js
+++ b/xfdcloser-src/Controllers/Tasks/AddToHoldingCell.js
@@ -44,7 +44,7 @@ export default class AddToHoldingCell extends TaskItemController {
 	transform(holdingCellPage) {
 		if ( this.model.aborted ) return rejection("aorted");
 		// Get page contents, split into section
-		const sectionsArray = holdingCellPage.content.split(/\n={3,}/).map(section => {
+		const sectionsArray = holdingCellPage.content.split(/\n={2,}/).map(section => {
 			const headingSigns = /^[^=]+(=+)\n/.exec(section);
 			if (!headingSigns) {
 				return section;


### PR DESCRIPTION
Proposed here: https://en.wikipedia.org/wiki/Wikipedia_talk:Templates_for_discussion#c-FaviFake-20260809084900-Novem_Linguae-20260808233800

Why: Editors can only use DiscussionTools to subscribe to a discussion if there's a level-2 header, but the page currently only has level-3 headers, so the script needs to be updated before this conversion from level-3 to level-2 can happen.